### PR TITLE
Want to properly localize 'File type'

### DIFF
--- a/src/localization/Spanish/localization.spanish.ts
+++ b/src/localization/Spanish/localization.spanish.ts
@@ -12,7 +12,7 @@ export const DropzoneSpanish: LocalLabels = {
     noFilesMessage: `No hay archivos válidos pendientes por subir`,
     footer: {
         acceptAll: `Todos los tipos de archivo aceptados`,
-        acceptCustom: (accept) => `File types: ${accept}`
+        acceptCustom: (accept) => `Tipo(s) de archivo permitidos: ${accept}`
     },
     header: {
         uploadFilesMessage: "Subir",


### PR DESCRIPTION
I propose to change 'file type' for - Tipo(s) de archivo permitido --> Which translates to 'Allowed types of file' and is in Spanish instead of 'file type'.