### PR TITLE
Capital letter on FileItem Status

### DIFF
--- a/src/localization/Spanish/localization.spanish.ts
+++ b/src/localization/Spanish/localization.spanish.ts
@@ -34,10 +34,10 @@ export const FileItemSpanish: LocalLabels = {
     },
     status: {
         uploading: "Subiendo",
-        success: "éxito",
-        valid: "válido",
-        denied: "no válido",
-        error: "error"
+        success: "Éxito",
+        valid: "Válido",
+        denied: "No válido",
+        error: "Error"
 
     },
 }


### PR DESCRIPTION
Changing the label in the FileItem status to start with Capital letters.